### PR TITLE
chore: downgrade go.mod version to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vito/bubbline
 
-go 1.24
+go 1.23
 
 require (
 	github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
We need this to be able to downgrade the engine version of go to 1.23 because of https://github.com/dagger/dagger/issues/9759